### PR TITLE
Fixed AV vendors static json in 'parse()'

### DIFF
--- a/vtlite.py
+++ b/vtlite.py
@@ -47,7 +47,6 @@ def md5sum(filename):
           break
       m.update(data)
   return m.hexdigest() 
-
           
 def parse(it, md5, verbose, jsondump):
   if it['response_code'] == 0:
@@ -90,7 +89,7 @@ def main():
   if options.search or options.jsondump or options.verbose:
     parse(vt.getReport(md5), md5 ,options.verbose, options.jsondump)
   if options.rescan:
-    vt.getReport(md5)
+    vt.rescan(md5)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Not all the sample have the same AV vendor detection. So I picked up 3 AV to show up in the summary report, checking if their name exists within the json/dict structure.
