### PR TITLE
Multiple Hash Searches with CSV File

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,43 @@
 ## Information
-This is a simple tool to utilize the basic functionality of the Private API From Virus Total, with this tool you can eaisly scan a hash or file (script will automatically hash the file and submit the HASH to VT not the file). You can download malware based on hash, download pcaps, write the full VT Json report to file, and force a rescan of a previously uploaded file with new AV definitions. Advanced queries and bulk downloads can be accomplished via VT Provided Scripts available on the Intelligence portal. (or a bash loop if you want to bulk DL with this)
+This is a simple tool to utilize the basic functionality of the Private API From Virus Total, with this tool you can easily scan a hash or file (script will automatically hash the file and submit the HASH to VT not the file). You can download malware based on hash, download pcaps, write the full VT JSON report to file, and force a rescan of a previously uploaded file with new AV definitions. Advanced queries and bulk downloads can be accomplished via VT Provided Scripts available on the Intelligence portal. (or a bash loop if you want to bulk DL with this)
 
-NOTE: You need your own premium VT API to use this tool. API Key Goes on Line 13!
+NOTE: You need your own premium VT API to use this tool. Set it up with '-k' option and your key.
 
-NOTE2: If you have a free VT Public API (you do) then you can use VTlite.py with limited functionality (Check Hash/Path/Rescan/DownloadJson/VerboseDetections) four checks per minute are allowed.
+NOTE2: If you have a free VT Public API (you do) then you can use VTlite.py with limited functionality (Check Hash/Path/Rescan/DownloadJson/VerboseDetections) four checks per minute are allowed. Load balancing has been built-in for multiple searches; single searches may still return errors.
 
 ## Authors & Licence
 Original Script Author: Adam Meyers
 
 Rewritten & Modified: Chris Clark
 
-API Key Setup: Chris Thurber
+API Key Setup & Multiple MD5 Search: Chris Thurber
 
 License: Do whatever you want with it :)
 
 ## Example
 <pre>
-Usage is as follows with an example of a basic search +  hitting all of
+Usage is as follows with an example of a basic search + hitting all of
 the switches below:
 
-usage: vt.py [-h] [-s] [-v] [-j] [-d] [-p] [-r] [-k] HashorPath
+usage: vt.py [-h] [-s] [-v] [-j] [-d] [-p] [-r] [-k] [-m] HashorPath/CSV File
 
 Search and Download from VirusTotal
 
 positional arguments:
  HashorPath      Enter the MD5 Hash or Path to File
+ CSV             Add a CSV with as many hashes as you like
 
 optional arguments:
- -h, --help      show this help message and exit
- -s, --search    Search VirusTotal
- -v, --verbose   Turn on verbosity of VT reports
- -j, --jsondump  Dumps the full VT report to file (VTDLXXX.json)
- -d, --download  Download File from Virustotal (VTDLXXX.danger)
- -p, --pcap      Download Network Traffic (VTDLXXX.pcap)
- -r, --rescan    Force Rescan with Current A/V Definitions
- -k, --addkey    Add your API key
+ -h, --help        Show this help message and exit
+ -s, --search      Search VirusTotal
+ -v, --verbose     Turn on verbosity of VT reports
+ -j, --jsondump    Dumps the full VT report to file (VTDLXXX.json)
+ -d, --download    Download File from Virustotal (VTDLXXX.danger)
+ -p, --pcap        Download Network Traffic (VTDLXXX.pcap)
+ -r, --rescan      Force Rescan with Current A/V Definitions
+ -k, --addkey      Add your API key
+ -c, --cleandump   Prints 'clean' console output to file
+ -m, --multisearch Lookup multiple SHA/MD5's by using a CSV as a parameter
 
 Example Basic Scan:
 

--- a/vtlite.py
+++ b/vtlite.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # Virus Total API Integration Script
 # Built on VT Test Script from: Adam Meyers ~ CrowdStrike
-# Rewirtten / Modified / Personalized: Chris Clark ~ GD Fidelis CyberSecurity
-# API Key Setup / Multiple MD5 Lookup: Chris Thurber
+# Rewirtten / Modified / Personalized: Chris Clark ~ Palo Alto Networks
+# API Key Setup / Multiple MD5 Lookup (and load balancing for free API): Chris Thurber
 # If things are broken let me know chris@xenosec.org
 # No License or warranty expressed or implied, use however you wish!
 

--- a/vtlite.py
+++ b/vtlite.py
@@ -76,7 +76,6 @@ def md5sum(filename):
       m.update(data)
   return m.hexdigest()
 
-#TODO convert tuples to strings...
 def parse(it, md5, verbose, jsondump, cleandump):
   dumpArray = []
   if it['response_code'] == 0:
@@ -85,7 +84,7 @@ def parse(it, md5, verbose, jsondump, cleandump):
     dumpArray.append(notfoundstr)
     return 0
   resultstr = str("\n\tResults for MD5: "+str(it['md5']))
-  detectedstr = str("\n\n\tDetected by: "+str(it['positives'])+'/'+str(it['total'])+'\n')
+  detectedstr = str("\n\tDetected by: "+str(it['positives'])+'/'+str(it['total'])+'\n')
   dumpArray.append(resultstr)
   dumpArray.append(detectedstr)
   print resultstr
@@ -136,15 +135,13 @@ def getHashes(mdFile):
   with open(mdFile, 'r') as mdf:
     for line in mdf:
       row = line.strip('\n').strip(',')
-      if len(str(row)) == 32:
-        hashes.append(row)
+      hashes.append(row)
   mdf.close()
   return hashes
 
 def parseMultipleMDF(hashArray, verbose, jsondump, cleandump):
   calls = 0
   for keyhash in hashArray:
-    print "running...", calls
     if calls == 0 or (calls%4) != 0:
       vt = vtAPI()
       parse(vt.getReport(keyhash), keyhash, verbose, jsondump, cleandump)
@@ -152,11 +149,12 @@ def parseMultipleMDF(hashArray, verbose, jsondump, cleandump):
     else:
       seconds = 61
       while seconds > 0:
-        sys.stdout.write('\r --- Waiting '+str(seconds)+' seconds... ---')
+        sys.stdout.write('\r\n\t --- Waiting '+str(seconds)+' seconds... ---')
         sys.stdout.flush()
         time.sleep(1)
         seconds -= 1
-      parseMultipleMDF(hashArray, verbose, jsondump, cleandump)
+      sys.stdout.flush()
+      parseMultipleMDF(hashArray[calls:], verbose, jsondump, cleandump)
 
 def main():
   opt=argparse.ArgumentParser(description="Search and Download from VirusTotal")


### PR DESCRIPTION
- Added Multiple MD5/SHA lookups. Just add a CSV with the hashes as a parameter and let it rip. Load balancing is built-in for the 'lite' version to avoid rate limits for CSVs with more than 4 hashes.
- Also included a 'clean dump' feature that outputs the smaller, 'cleaner' console output to a text file.

(Double-checked for bugs this time)