### PR TITLE
warn user if they hadn't changed API key

### DIFF
--- a/vt.py
+++ b/vt.py
@@ -8,9 +8,12 @@
 import json, urllib, urllib2, argparse, hashlib, re, sys
 from pprint import pprint
 
+
 class vtAPI():
     def __init__(self):
-        self.api = '<--------------PRIVATE-API-KEY-GOES-HERE----->'
+        your_private_api_key = '<--------------PRIVATE-API-KEY-GOES-HERE----->'
+        assert "KEY-GOES-HERE" not in your_private_api_key
+        self.api = your_private_api_key
         self.base = 'https://www.virustotal.com/vtapi/v2/'
     
     def getReport(self,md5):

--- a/vt.py
+++ b/vt.py
@@ -11,11 +11,14 @@ from pprint import pprint
 
 class vtAPI():
     def __init__(self):
-        your_private_api_key = '<--------------PRIVATE-API-KEY-GOES-HERE----->'
-        assert "KEY-GOES-HERE" not in your_private_api_key
-        self.api = your_private_api_key
-        self.base = 'https://www.virustotal.com/vtapi/v2/'
-    
+        try:
+            your_private_api_key = '<--------------PRIVATE-API-KEY-GOES-HERE----->'
+            assert "KEY-GOES-HERE" not in your_private_api_key
+            self.api = your_private_api_key
+            self.base = 'https://www.virustotal.com/vtapi/v2/'
+        except AssertionError:
+            raise ValueError("Private API key not provided.")
+
     def getReport(self,md5):
         param = {'resource':md5,'apikey':self.api,'allinfo': '1'}
         url = self.base + "file/report"

--- a/vtlite.py
+++ b/vtlite.py
@@ -8,9 +8,12 @@
 import json, urllib, urllib2, argparse, hashlib, re, sys
 from pprint import pprint
 
+
 class vtAPI():
     def __init__(self):
-        self.api = '<--------------PUBLIC-API-KEY-GOES-HERE----->'
+        your_public_api_key = '<--------------PUBLIC-API-KEY-GOES-HERE----->'
+        assert "KEY-GOES-HERE" not in your_public_api_key
+        self.api = your_public_api_key
         self.base = 'https://www.virustotal.com/vtapi/v2/'
     
     def getReport(self,md5):

--- a/vtlite.py
+++ b/vtlite.py
@@ -11,11 +11,14 @@ from pprint import pprint
 
 class vtAPI():
     def __init__(self):
-        your_public_api_key = '<--------------PUBLIC-API-KEY-GOES-HERE----->'
-        assert "KEY-GOES-HERE" not in your_public_api_key
-        self.api = your_public_api_key
-        self.base = 'https://www.virustotal.com/vtapi/v2/'
-    
+        try:
+            your_public_api_key = '<--------------PUBLIC-API-KEY-GOES-HERE----->'
+            assert "KEY-GOES-HERE" not in your_public_api_key
+            self.api = your_public_api_key
+            self.base = 'https://www.virustotal.com/vtapi/v2/'
+        except AssertionError:
+            raise ValueError("Private API key not provided.")
+
     def getReport(self,md5):
         param = {'resource':md5,'apikey':self.api}
         url = self.base + "file/report"


### PR DESCRIPTION
Display more understandable/trackable error message about missing API key:
```
...
File "./vtlite.py", line 15, in __init__
    assert "KEY-GOES-HERE" not in your_public_api_key
AssertionError
```